### PR TITLE
Refactor to have more granular plugins

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,0 +1,41 @@
+use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
+use crate::{player::PLAYER_CONFIG, CONFIG};
+
+pub struct CameraPlugin;
+
+impl Plugin for CameraPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(Startup, setup).add_systems(Update, camera_follow_system);
+	}
+}
+
+fn setup(mut commands: Commands) {
+	commands.spawn(Camera2dBundle::default());
+}
+
+fn camera_follow_system(
+	player_query: Query<&Transform, With<KinematicCharacterControllerOutput>>,
+	mut camera_query: Query<
+		&mut Transform,
+		(With<Camera>, Without<KinematicCharacterControllerOutput>),
+	>,
+) {
+	if let Ok(player_transform) = player_query.get_single() {
+		if let Ok(mut camera_transform) = camera_query.get_single_mut() {
+			let player_x = player_transform.translation.x;
+			let camera_x = camera_transform.translation.x;
+			let left_bound = camera_x - (CONFIG.window_width / 2.)
+				+ PLAYER_CONFIG.camera_edge_boundary;
+			let right_bound = camera_x + (CONFIG.window_width / 2.)
+				- PLAYER_CONFIG.camera_edge_boundary;
+
+			if player_x > right_bound {
+				camera_transform.translation.x += player_x - right_bound;
+			} else if player_x < left_bound {
+				camera_transform.translation.x += player_x - left_bound;
+			}
+		}
+	}
+}

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,0 +1,88 @@
+use crate::animation::Animation;
+use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+use std::time::Duration;
+
+#[derive(Component, Copy, Clone)]
+pub enum Direction {
+	Right,
+	Left,
+}
+
+pub struct DefaultCharacterConfig {
+	starting_x: f32,
+	starting_y: f32,
+	sprite_render_width: f32,
+	sprite_render_height: f32,
+	cycle_delay: Duration,
+	velocity: Velocity,
+	direction: Direction,
+}
+
+#[derive(Component, Copy, Clone)]
+pub struct Velocity {
+	pub x: f32,
+	pub y: f32,
+}
+
+pub static DEFAULT_CHARACTER_CONFIG: DefaultCharacterConfig =
+	DefaultCharacterConfig {
+		starting_x: 0.0,
+		starting_y: 0.0,
+		sprite_render_width: 64.0,
+		sprite_render_height: 64.0,
+		cycle_delay: Duration::from_millis(100),
+		velocity: Velocity { x: 300.0, y: 650.0 },
+		direction: Direction::Right,
+	};
+
+#[derive(Bundle)]
+pub struct CharacterBundle {
+	pub sprite: SpriteBundle,
+	pub animation: Animation,
+	pub texture_atlas: TextureAtlas,
+	pub body: RigidBody,
+	pub collider: Collider,
+	pub controller: KinematicCharacterController,
+	pub velocity: Velocity,
+	pub direction: Direction,
+}
+
+impl Default for CharacterBundle {
+	fn default() -> Self {
+		Self {
+			sprite: SpriteBundle {
+				sprite: Sprite {
+					custom_size: Some(Vec2::new(
+						DEFAULT_CHARACTER_CONFIG.sprite_render_width,
+						DEFAULT_CHARACTER_CONFIG.sprite_render_height,
+					)),
+					..default()
+				},
+				transform: Transform {
+					translation: Vec3::new(
+						DEFAULT_CHARACTER_CONFIG.starting_x,
+						DEFAULT_CHARACTER_CONFIG.starting_y,
+						1.0,
+					),
+					scale: Vec3::new(1.0, 1.0, 1.0),
+					..default()
+				},
+				..default()
+			},
+			texture_atlas: TextureAtlas {
+				layout: Handle::default(),
+				index: 0,
+			},
+			body: RigidBody::KinematicPositionBased,
+			collider: Collider::cuboid(
+				DEFAULT_CHARACTER_CONFIG.sprite_render_width / 2.0,
+				DEFAULT_CHARACTER_CONFIG.sprite_render_height / 2.0,
+			),
+			controller: KinematicCharacterController::default(),
+			animation: Animation::new(&[0], DEFAULT_CHARACTER_CONFIG.cycle_delay),
+			velocity: DEFAULT_CHARACTER_CONFIG.velocity,
+			direction: DEFAULT_CHARACTER_CONFIG.direction,
+		}
+	}
+}

--- a/src/character.rs
+++ b/src/character.rs
@@ -9,6 +9,12 @@ pub enum Direction {
 	Left,
 }
 
+#[derive(Component, Copy, Clone)]
+pub struct Velocity {
+	pub x: f32,
+	pub y: f32,
+}
+
 pub struct DefaultCharacterConfig {
 	starting_x: f32,
 	starting_y: f32,
@@ -17,12 +23,6 @@ pub struct DefaultCharacterConfig {
 	cycle_delay: Duration,
 	velocity: Velocity,
 	direction: Direction,
-}
-
-#[derive(Component, Copy, Clone)]
-pub struct Velocity {
-	pub x: f32,
-	pub y: f32,
 }
 
 pub static DEFAULT_CHARACTER_CONFIG: DefaultCharacterConfig =

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,39 @@
+use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
+use crate::{character::Velocity, player::Player};
+
+pub struct InputPlugin;
+
+impl Plugin for InputPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(Update, movement_input);
+	}
+}
+
+fn movement_input(
+	input: Res<ButtonInput<KeyCode>>,
+	time: Res<Time>,
+	mut player_query: Query<&mut KinematicCharacterController>,
+	velocity_query: Query<&Velocity, With<Player>>,
+) {
+	let mut player = player_query.single_mut();
+	let velocity = velocity_query.single();
+
+	let mut movement = 0.0;
+
+	if input.pressed(KeyCode::ArrowRight) {
+		movement += time.delta_seconds() * velocity.x;
+	}
+
+	if input.pressed(KeyCode::ArrowLeft) {
+		movement += time.delta_seconds() * velocity.x * -1.0;
+	}
+
+	if let Some(mut translation) = player.translation {
+		translation.x = movement;
+		player.translation = Some(translation);
+	} else {
+		player.translation = Some(Vec2::new(movement, 0.0));
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,13 @@ use bevy_rapier2d::prelude::*;
 mod animation;
 mod character;
 mod input;
+mod movement;
 mod platforms;
 mod player;
 
 use animation::AnimationPlugin;
 use input::InputPlugin;
+use movement::MovementPlugin;
 use platforms::PlatformsPlugin;
 use player::PlayerPlugin;
 
@@ -55,6 +57,7 @@ fn main() {
 		.add_plugins(PlayerPlugin)
 		.add_plugins(AnimationPlugin)
 		.add_plugins(InputPlugin)
+		.add_plugins(MovementPlugin)
 		.add_systems(Startup, setup)
 		.run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use bevy::{prelude::*, window::WindowResolution};
 use bevy_rapier2d::prelude::*;
 
 mod animation;
+mod character;
 mod platforms;
 mod player;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,12 @@ use bevy_rapier2d::prelude::*;
 
 mod animation;
 mod character;
+mod input;
 mod platforms;
 mod player;
 
 use animation::AnimationPlugin;
+use input::InputPlugin;
 use platforms::PlatformsPlugin;
 use player::PlayerPlugin;
 
@@ -52,6 +54,7 @@ fn main() {
 		.add_plugins(PlatformsPlugin)
 		.add_plugins(PlayerPlugin)
 		.add_plugins(AnimationPlugin)
+		.add_plugins(InputPlugin)
 		.add_systems(Startup, setup)
 		.run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use bevy::{prelude::*, window::WindowResolution};
 use bevy_rapier2d::prelude::*;
 
 mod animation;
+mod camera;
 mod character;
 mod input;
 mod movement;
@@ -9,6 +10,7 @@ mod platforms;
 mod player;
 
 use animation::AnimationPlugin;
+use camera::CameraPlugin;
 use input::InputPlugin;
 use movement::MovementPlugin;
 use platforms::PlatformsPlugin;
@@ -58,13 +60,12 @@ fn main() {
 		.add_plugins(AnimationPlugin)
 		.add_plugins(InputPlugin)
 		.add_plugins(MovementPlugin)
+		.add_plugins(CameraPlugin)
 		.add_systems(Startup, setup)
 		.run();
 }
 
 fn setup(mut commands: Commands) {
-	commands.spawn(Camera2dBundle::default());
-
 	commands
 		.spawn(SpriteBundle {
 			sprite: Sprite {

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -67,7 +67,7 @@ fn rise(
 		CONTROL_POINTS[3].1,
 	) * jump_height;
 
-	// Update the player's vertical position
+	// Update the character's vertical position
 	match character.translation {
 		Some(vec) => character.translation = Some(Vec2::new(vec.x, new_height)),
 		None => character.translation = Some(Vec2::new(0.0, new_height)),
@@ -86,12 +86,12 @@ fn fall(
 		return;
 	}
 
-	let mut player = character_query.single_mut();
+	let mut character = character_query.single_mut();
 	let velocity = velocity_query.single();
 	let movement = time.delta().as_secs_f32() * (velocity.y / 1.5) * -1.0;
 
-	match player.translation {
-		Some(vec) => player.translation = Some(Vec2::new(vec.x, movement)),
-		None => player.translation = Some(Vec2::new(0.0, movement)),
+	match character.translation {
+		Some(vec) => character.translation = Some(Vec2::new(vec.x, movement)),
+		None => character.translation = Some(Vec2::new(0.0, movement)),
 	}
 }

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -1,0 +1,97 @@
+use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
+use crate::character::Velocity;
+
+pub struct MovementPlugin;
+
+impl Plugin for MovementPlugin {
+	fn build(&self, app: &mut App) {
+		app.add_systems(Update, rise).add_systems(Update, fall);
+	}
+}
+
+#[derive(Component)]
+pub struct Jump {
+	pub total: f32,
+	pub duration: f32,
+	pub max_height: f32,
+}
+
+// Define control points for the cubic Bezier curve
+const CONTROL_POINTS: [(f32, f32); 4] = [
+	(0.0, 0.0),      // Starting point
+	(0.0075, 0.009), // Control point 1
+	(0.0075, 0.009), // Control point 2
+	(0.01, 0.0),     // End point
+];
+
+// Cubic Bezier function
+fn cubic_bezier(t: f32, p0: f32, p1: f32, p2: f32, p3: f32) -> f32 {
+	let u = 1.0 - t;
+	let tt = t * t;
+	let uu = u * u;
+	let uuu = uu * u;
+	let ttt = tt * t;
+
+	uuu * p0 + 3.0 * uu * t * p1 + 3.0 * u * tt * p2 + ttt * p3
+}
+
+fn rise(
+	mut commands: Commands,
+	time: Res<Time>,
+	mut query: Query<(Entity, &mut KinematicCharacterController, &mut Jump)>,
+) {
+	if query.is_empty() {
+		return;
+	}
+
+	let (entity, mut character, mut jump) = query.single_mut();
+
+	let jump_duration = jump.duration;
+	let jump_height = jump.max_height;
+
+	// Calculate the time passed as a fraction of the total jump duration
+	let t = jump.total / jump_duration;
+	if t >= 1.0 {
+		commands.entity(entity).remove::<Jump>();
+		return;
+	}
+
+	// Calculate the new height using the cubic Bezier curve
+	let new_height = cubic_bezier(
+		t,
+		CONTROL_POINTS[0].1,
+		CONTROL_POINTS[1].1,
+		CONTROL_POINTS[2].1,
+		CONTROL_POINTS[3].1,
+	) * jump_height;
+
+	// Update the player's vertical position
+	match character.translation {
+		Some(vec) => character.translation = Some(Vec2::new(vec.x, new_height)),
+		None => character.translation = Some(Vec2::new(0.0, new_height)),
+	}
+
+	// Update the jump timer
+	jump.total += time.delta().as_secs_f32();
+}
+
+fn fall(
+	time: Res<Time>,
+	mut character_query: Query<&mut KinematicCharacterController, Without<Jump>>,
+	velocity_query: Query<&Velocity>,
+) {
+	if character_query.is_empty() {
+		return;
+	}
+
+	let mut player = character_query.single_mut();
+	let velocity = velocity_query.single();
+	let movement = time.delta().as_secs_f32() * (velocity.y / 1.5) * -1.0;
+
+	match player.translation {
+		Some(vec) => player.translation = Some(Vec2::new(vec.x, movement)),
+		None => player.translation = Some(Vec2::new(0.0, movement)),
+	}
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -58,7 +58,6 @@ impl Plugin for PlayerPlugin {
 	fn build(&self, app: &mut App) {
 		app
 			.add_systems(Startup, setup)
-			.add_systems(Update, movement)
 			.add_systems(Update, jump)
 			.add_systems(Update, rise)
 			.add_systems(Update, fall)
@@ -72,7 +71,7 @@ impl Plugin for PlayerPlugin {
 }
 
 #[derive(Component)]
-struct Player {}
+pub struct Player {}
 
 fn setup(
 	mut commands: Commands,
@@ -130,33 +129,6 @@ fn setup(
 			..default()
 		},
 	));
-}
-
-fn movement(
-	input: Res<ButtonInput<KeyCode>>,
-	time: Res<Time>,
-	mut player_query: Query<&mut KinematicCharacterController>,
-	velocity_query: Query<&Velocity, With<Player>>,
-) {
-	let mut player = player_query.single_mut();
-	let velocity = velocity_query.single();
-
-	let mut movement = 0.0;
-
-	if input.pressed(KeyCode::ArrowRight) {
-		movement += time.delta_seconds() * velocity.x;
-	}
-
-	if input.pressed(KeyCode::ArrowLeft) {
-		movement += time.delta_seconds() * velocity.x * -1.0;
-	}
-
-	if let Some(mut translation) = player.translation {
-		translation.x = movement;
-		player.translation = Some(translation);
-	} else {
-		player.translation = Some(Vec2::new(movement, 0.0));
-	}
 }
 
 #[derive(Component)]

--- a/src/player.rs
+++ b/src/player.rs
@@ -62,8 +62,7 @@ impl Plugin for PlayerPlugin {
 			.add_systems(Update, apply_idle_animation)
 			.add_systems(Update, apply_jumping_animation)
 			.add_systems(Update, update_direction)
-			.add_systems(Update, update_sprite_direction)
-			.add_systems(Update, camera_follow_system);
+			.add_systems(Update, update_sprite_direction);
 	}
 }
 
@@ -194,30 +193,5 @@ fn update_sprite_direction(mut query: Query<(&mut Sprite, &Direction)>) {
 	match direction {
 		Direction::Right => sprite.flip_x = false,
 		Direction::Left => sprite.flip_x = true,
-	}
-}
-
-fn camera_follow_system(
-	player_query: Query<&Transform, With<KinematicCharacterControllerOutput>>,
-	mut camera_query: Query<
-		&mut Transform,
-		(With<Camera>, Without<KinematicCharacterControllerOutput>),
-	>,
-) {
-	if let Ok(player_transform) = player_query.get_single() {
-		if let Ok(mut camera_transform) = camera_query.get_single_mut() {
-			let player_x = player_transform.translation.x;
-			let camera_x = camera_transform.translation.x;
-			let left_bound = camera_x - (CONFIG.window_width / 2.)
-				+ PLAYER_CONFIG.camera_edge_boundary;
-			let right_bound = camera_x + (CONFIG.window_width / 2.)
-				- PLAYER_CONFIG.camera_edge_boundary;
-
-			if player_x > right_bound {
-				camera_transform.translation.x += player_x - right_bound;
-			} else if player_x < left_bound {
-				camera_transform.translation.x += player_x - left_bound;
-			}
-		}
 	}
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -8,29 +8,29 @@ use crate::{
 	CONFIG,
 };
 
-struct PlayerConfig {
-	player_starting_x: f32,
-	player_starting_y: f32,
-	player_velocity_x: f32,
-	player_velocity_y: f32,
-	max_jump_height: f32,
-	jump_duration: f32,
-	spritesheet_cols: u32,
-	spritesheet_rows: u32,
-	sprite_path: &'static str,
-	sprite_tile_width: f32,
-	sprite_tile_height: f32,
-	sprite_render_width: f32,
-	sprite_render_height: f32,
-	sprite_idx_stand: usize,
-	sprite_idx_idle: &'static [usize; 4],
-	sprite_idx_walking: &'static [usize; 9],
-	sprite_idx_jumping: &'static [usize; 7],
-	cycle_delay: Duration,
-	camera_edge_boundary: f32,
+pub struct PlayerConfig {
+	pub player_starting_x: f32,
+	pub player_starting_y: f32,
+	pub player_velocity_x: f32,
+	pub player_velocity_y: f32,
+	pub max_jump_height: f32,
+	pub jump_duration: f32,
+	pub spritesheet_cols: u32,
+	pub spritesheet_rows: u32,
+	pub sprite_path: &'static str,
+	pub sprite_tile_width: f32,
+	pub sprite_tile_height: f32,
+	pub sprite_render_width: f32,
+	pub sprite_render_height: f32,
+	pub sprite_idx_stand: usize,
+	pub sprite_idx_idle: &'static [usize; 4],
+	pub sprite_idx_walking: &'static [usize; 9],
+	pub sprite_idx_jumping: &'static [usize; 7],
+	pub cycle_delay: Duration,
+	pub camera_edge_boundary: f32,
 }
 
-static PLAYER_CONFIG: PlayerConfig = PlayerConfig {
+pub static PLAYER_CONFIG: PlayerConfig = PlayerConfig {
 	player_starting_x: CONFIG.window_left_x + 100.0,
 	player_starting_y: CONFIG.window_bottom_y + 300.0,
 	player_velocity_x: 400.0,
@@ -58,9 +58,6 @@ impl Plugin for PlayerPlugin {
 	fn build(&self, app: &mut App) {
 		app
 			.add_systems(Startup, setup)
-			.add_systems(Update, jump)
-			.add_systems(Update, rise)
-			.add_systems(Update, fall)
 			.add_systems(Update, apply_movement_animation)
 			.add_systems(Update, apply_idle_animation)
 			.add_systems(Update, apply_jumping_animation)
@@ -129,107 +126,6 @@ fn setup(
 			..default()
 		},
 	));
-}
-
-#[derive(Component)]
-struct Jump(f32);
-
-// Define control points for the cubic Bezier curve
-const CONTROL_POINTS: [(f32, f32); 4] = [
-	(0.0, 0.0),      // Starting point
-	(0.0075, 0.009), // Control point 1
-	(0.0075, 0.009), // Control point 2
-	(0.01, 0.0),     // End point
-];
-
-// Cubic Bezier function
-fn cubic_bezier(t: f32, p0: f32, p1: f32, p2: f32, p3: f32) -> f32 {
-	let u = 1.0 - t;
-	let tt = t * t;
-	let uu = u * u;
-	let uuu = uu * u;
-	let ttt = tt * t;
-
-	uuu * p0 + 3.0 * uu * t * p1 + 3.0 * u * tt * p2 + ttt * p3
-}
-
-#[allow(clippy::type_complexity)]
-fn jump(
-	input: Res<ButtonInput<KeyCode>>,
-	mut commands: Commands,
-	query: Query<
-		(Entity, &KinematicCharacterControllerOutput),
-		(With<KinematicCharacterController>, Without<Jump>),
-	>,
-) {
-	if query.is_empty() {
-		return;
-	}
-
-	let (player, output) = query.single();
-
-	if input.pressed(KeyCode::ArrowUp) && output.grounded {
-		commands.entity(player).insert(Jump(0.0));
-	}
-}
-
-fn rise(
-	mut commands: Commands,
-	time: Res<Time>,
-	mut query: Query<(Entity, &mut KinematicCharacterController, &mut Jump)>,
-) {
-	if query.is_empty() {
-		return;
-	}
-
-	let (entity, mut player, mut jump) = query.single_mut();
-
-	let jump_duration = PLAYER_CONFIG.jump_duration;
-	let jump_height = PLAYER_CONFIG.max_jump_height;
-
-	// Calculate the time passed as a fraction of the total jump duration
-	let t = jump.0 / jump_duration;
-	if t >= 1.0 {
-		commands.entity(entity).remove::<Jump>();
-		return;
-	}
-
-	// Calculate the new height using the cubic Bezier curve
-	let new_height = cubic_bezier(
-		t,
-		CONTROL_POINTS[0].1,
-		CONTROL_POINTS[1].1,
-		CONTROL_POINTS[2].1,
-		CONTROL_POINTS[3].1,
-	) * jump_height;
-
-	// Update the player's vertical position
-	match player.translation {
-		Some(vec) => player.translation = Some(Vec2::new(vec.x, new_height)),
-		None => player.translation = Some(Vec2::new(0.0, new_height)),
-	}
-
-	// Update the jump timer
-	jump.0 += time.delta().as_secs_f32();
-}
-
-fn fall(
-	time: Res<Time>,
-	mut player_query: Query<&mut KinematicCharacterController, Without<Jump>>,
-	velocity_query: Query<&Velocity, With<Player>>,
-) {
-	if player_query.is_empty() {
-		return;
-	}
-
-	let mut player = player_query.single_mut();
-	let velocity = velocity_query.single();
-	let movement = time.delta().as_secs_f32() * (velocity.y / 1.5) * -1.0;
-
-	match player.translation {
-		Some(vec) => player.translation = Some(Vec2::new(vec.x, movement)),
-		None => player.translation = Some(Vec2::new(0.0, movement)),
-	}
 }
 
 fn apply_movement_animation(


### PR DESCRIPTION
Trying to organize our modules and plugins for more reusability. Following the cheatbook on:
* [bundles](https://bevy-cheatbook.github.io/programming/bundle.html).
* [plugins](https://bevy-cheatbook.github.io/programming/plugins.html)

### `CharacterBundle`
My thinking here is that `Character` is  a generic base for `Player` and `Enemy`. We'll be able to add more components to `Character` when we're ready like `Health` 

### `InputPlugin`
Breaking out `movement` into an `input` plugin so that we can add/update different keybindings to do various things

### `MovementPlugin`
I'm thinking this could be generalized to be used for enemies as well. It could even be used for objects that aren't characters but maybe we'll want to rethink it when we're ready for that

### `CameraPlugin`